### PR TITLE
Update Deprecated `gradle-build-action` to `gradle/setup-gradle`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
           java-version: "22"
 
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Java tests
         run: gradle test
@@ -77,7 +77,7 @@ jobs:
           java-version: "22"
 
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Java tests
         run: gradle test
@@ -106,7 +106,7 @@ jobs:
           java-version: "22"
 
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Java tests
         run: gradle test


### PR DESCRIPTION
### Description:

This PR updates the deprecated `gradle-build-action` to the recommended `gradle/setup-gradle`.

For more details, refer to the [deprecation upgrade guide](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle).