### PR TITLE
`fs-index`: Track API 

### DIFF
--- a/fs-index/README.md
+++ b/fs-index/README.md
@@ -10,10 +10,11 @@ The most important struct in this crate is `ResourceIndex` which comes with:
 
 - **Reactive API**
   - `update_all`: Method to update the index by rescanning files and returning changes (additions/deletions).
-  - `update_one`: Method to update the index by rescanning a single file (addition/deletion/modification).
 - **Snapshot API**
   - `get_resources_by_id`: Query resources from the index by ID.
   - `get_resource_by_path`: Query a resource from the index by its path.
+- **Selective API**
+  - `update_one`: Method to manually update a specific resource by selectively rescanning a single file.
 
 ## Custom Serialization
 

--- a/fs-index/README.md
+++ b/fs-index/README.md
@@ -10,6 +10,7 @@ The most important struct in this crate is `ResourceIndex` which comes with:
 
 - **Reactive API**
   - `update_all`: Method to update the index by rescanning files and returning changes (additions/deletions).
+  - `update_one`: Method to update the index by rescanning a single file (addition/deletion/modification).
 - **Snapshot API**
   - `get_resources_by_id`: Query resources from the index by ID.
   - `get_resource_by_path`: Query a resource from the index by its path.

--- a/fs-index/benches/resource_index_benchmark.rs
+++ b/fs-index/benches/resource_index_benchmark.rs
@@ -112,24 +112,35 @@ fn resource_index_benchmark(c: &mut Criterion) {
                 ResourceIndex::build(black_box(&update_one_benchmarks_dir))
                     .unwrap();
 
-            // Create a new file
-            let new_file = update_one_benchmarks_dir.join("new_file.txt");
-            std::fs::File::create(&new_file).unwrap();
-            std::fs::write(&new_file, "Hello, World from new file!").unwrap();
+            // Create 1000 new files
+            for i in 5000..6000 {
+                let new_file =
+                    update_one_benchmarks_dir.join(format!("file_{}.txt", i));
+                std::fs::File::create(&new_file).unwrap();
+                std::fs::write(&new_file, format!("Hello, World! {}", i))
+                    .unwrap();
+            }
 
-            // Modify an existing file
-            let modified_file = update_one_benchmarks_dir.join("file_0.txt");
-            std::fs::write(&modified_file, "Hello, World from modified file!")
-                .unwrap();
+            // Modify 1000 files
+            for i in 4000..5000 {
+                let modified_file =
+                    update_one_benchmarks_dir.join(format!("file_{}.txt", i));
+                std::fs::write(&modified_file, format!("Bye, World! {}", i))
+                    .unwrap();
+            }
 
-            // Remove an existing file
-            let removed_file = update_one_benchmarks_dir.join("file_1.txt");
-            std::fs::remove_file(&removed_file).unwrap();
+            // Remove 1000 files
+            for i in 3000..4000 {
+                let removed_file =
+                    update_one_benchmarks_dir.join(format!("file_{}.txt", i));
+                std::fs::remove_file(&removed_file).unwrap();
+            }
 
-            // Update the index
-            let _update_result = index.update_one("new_file.txt").unwrap();
-            let _update_result = index.update_one("file_0.txt").unwrap();
-            let _update_result = index.update_one("file_1.txt").unwrap();
+            // Call update_one for each of the 3000 files
+            for i in 3000..6000 {
+                let file_path = format!("file_{}.txt", i);
+                let _update_result = index.update_one(&file_path).unwrap();
+            }
         });
     });
 

--- a/fs-index/benches/resource_index_benchmark.rs
+++ b/fs-index/benches/resource_index_benchmark.rs
@@ -84,6 +84,55 @@ fn resource_index_benchmark(c: &mut Criterion) {
         });
     });
 
+    // Benchmark `ResourceIndex::update_one()`
+
+    // First, create a new temp directory specifically for the update_one
+    // benchmark since we will be creating new files, removing files, and
+    // modifying files
+
+    let update_one_benchmarks_dir =
+        TempDir::with_prefix("ark-fs-index-benchmarks-update-one").unwrap();
+    let update_one_benchmarks_dir = update_one_benchmarks_dir.path();
+
+    group.bench_function("index_update_one", |b| {
+        b.iter(|| {
+            // Clear the directory
+            std::fs::remove_dir_all(&update_one_benchmarks_dir).unwrap();
+            std::fs::create_dir(&update_one_benchmarks_dir).unwrap();
+
+            // Create 5000 new files
+            for i in 0..5000 {
+                let new_file =
+                    update_one_benchmarks_dir.join(format!("file_{}.txt", i));
+                std::fs::File::create(&new_file).unwrap();
+                std::fs::write(&new_file, format!("Hello, World! {}", i))
+                    .unwrap();
+            }
+            let mut index: ResourceIndex<Crc32> =
+                ResourceIndex::build(black_box(&update_one_benchmarks_dir))
+                    .unwrap();
+
+            // Create a new file
+            let new_file = update_one_benchmarks_dir.join("new_file.txt");
+            std::fs::File::create(&new_file).unwrap();
+            std::fs::write(&new_file, "Hello, World from new file!").unwrap();
+
+            // Modify an existing file
+            let modified_file = update_one_benchmarks_dir.join("file_0.txt");
+            std::fs::write(&modified_file, "Hello, World from modified file!")
+                .unwrap();
+
+            // Remove an existing file
+            let removed_file = update_one_benchmarks_dir.join("file_1.txt");
+            std::fs::remove_file(&removed_file).unwrap();
+
+            // Update the index
+            let _update_result = index.update_one("new_file.txt").unwrap();
+            let _update_result = index.update_one("file_0.txt").unwrap();
+            let _update_result = index.update_one("file_1.txt").unwrap();
+        });
+    });
+
     group.finish();
 }
 

--- a/fs-index/src/index.rs
+++ b/fs-index/src/index.rs
@@ -8,7 +8,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use data_error::{ArklibError, Result};
+use data_error::Result;
 use data_resource::ResourceId;
 use fs_storage::{ARK_FOLDER, INDEX_PATH};
 
@@ -500,12 +500,12 @@ impl<Id: ResourceId> ResourceIndex<Id> {
             // If the entry does not exist in the file system, it's a removal
 
             // Remove the resource from the path to ID map
-            let id = self.path_to_id.remove(path).ok_or_else(|| {
-                ArklibError::Path(format!(
-                    "Path {:?} not found in the index",
-                    path
-                ))
-            })?;
+            debug_assert!(
+                self.path_to_id.contains_key(path),
+                "Caller must ensure that the resource exists in the index: {:?}",
+                path
+            );
+            let id = self.path_to_id.remove(path).unwrap();
             self.id_to_paths
                 .get_mut(&id.item)
                 .unwrap()

--- a/fs-index/src/index.rs
+++ b/fs-index/src/index.rs
@@ -75,8 +75,7 @@ type IndexedPaths = HashSet<Timestamped<PathBuf>>;
 /// #### Reactive API
 /// - [`ResourceIndex::update_all`]: Method to update the index by rescanning
 ///   files and returning changes (additions/deletions/updates).
-/// - [`ResourceIndex::update_one`]: Method to update the index for a single
-///   resource.
+
 ///
 /// #### Snapshot API
 /// - [`ResourceIndex::get_resources_by_id`]: Query resources from the index by
@@ -84,6 +83,10 @@ type IndexedPaths = HashSet<Timestamped<PathBuf>>;
 /// - [`ResourceIndex::get_resource_by_path`]: Query a resource from the index
 ///   by its path.
 ///
+/// ### Selective API
+/// - [`ResourceIndex::update_one`]: A method to manually update a specific
+///   resource by selectively rescanning a single file. Unlike the reactive
+///   nature of `update_all()`, this method allows for targeted updates.
 ///
 ///
 /// ## Examples

--- a/fs-index/src/index.rs
+++ b/fs-index/src/index.rs
@@ -83,10 +83,11 @@ type IndexedPaths = HashSet<Timestamped<PathBuf>>;
 /// - [`ResourceIndex::get_resource_by_path`]: Query a resource from the index
 ///   by its path.
 ///
-/// ### Selective API
-/// - [`ResourceIndex::update_one`]: A method to manually update a specific
-///   resource by selectively rescanning a single file. Unlike the reactive
-///   nature of `update_all()`, this method allows for targeted updates.
+/// #### Selective API
+/// - [`ResourceIndex::update_one`]: An experimental method to manually update a
+///   specific resource by rescanning a single file. It provides targeted
+///   control but is less dynamic than the reactive `update_all()`. The reactive
+///   API is typically preferred for broader updates.
 ///
 ///
 /// ## Examples

--- a/fs-index/src/index.rs
+++ b/fs-index/src/index.rs
@@ -75,6 +75,8 @@ type IndexedPaths = HashSet<Timestamped<PathBuf>>;
 /// #### Reactive API
 /// - [`ResourceIndex::update_all`]: Method to update the index by rescanning
 ///   files and returning changes (additions/deletions/updates).
+/// - [`ResourceIndex::update_one`]: Method to update the index for a single
+///   resource.
 ///
 /// #### Snapshot API
 /// - [`ResourceIndex::get_resources_by_id`]: Query resources from the index by
@@ -82,13 +84,7 @@ type IndexedPaths = HashSet<Timestamped<PathBuf>>;
 /// - [`ResourceIndex::get_resource_by_path`]: Query a resource from the index
 ///   by its path.
 ///
-/// #### Track API
-/// Allows for fine-grained control over tracking changes in the index
-/// - [`ResourceIndex::track_addition`]: Track a newly added file (checks if the
-///   file exists in the file system).
-/// - [`ResourceIndex::track_removal`]: Track the deletion of a file (checks if
-///   the file was actually deleted).
-/// - [`ResourceIndex::track_modification`]: Track an update on a single file.
+///
 ///
 /// ## Examples
 /// ```no_run
@@ -97,7 +93,7 @@ type IndexedPaths = HashSet<Timestamped<PathBuf>>;
 /// use dev_hash::Crc32;
 ///
 /// // Define the root path
-/// let root_path = Path::new("animals");
+/// let root_path = Path::new("path/to/animals");
 ///
 /// // Build the index
 /// let index: ResourceIndex<Crc32> = ResourceIndex::build(root_path).expect("Failed to build index");

--- a/fs-storage/src/file_storage.rs
+++ b/fs-storage/src/file_storage.rs
@@ -362,7 +362,7 @@ mod tests {
         file_storage.set("key1".to_string(), "value1".to_string());
         file_storage.set("key1".to_string(), "value2".to_string());
         assert!(file_storage.write_fs().is_ok());
-        assert_eq!(storage_path.exists(), true);
+        assert!(storage_path.exists());
 
         if let Err(err) = file_storage.erase() {
             panic!("Failed to delete file: {:?}", err);


### PR DESCRIPTION
## Description

This PR adds a new method to the `ResourceIndex` in the `fs-index` crate. The added method, `update_one`, allows the index to be updated with the latest information from the file system for a single resource. It handles updates for resources that have been added, removed, or modified.

Fixes #84
## Changes
- **New Method**: `ResourceIndex::update_one`
- **Added Tests**:
	- `test_track_removal`
	- `test_track_modification`
	- `test_track_removal_with_collision`
	- `test_track_addition`
	- `test_track_modification_with_collision`
	- `test_track_addition_with_collision`
- **Added Benchmarks**:
	- `index_update_one`