### PR TITLE
chore: implement suggestions from `cargo clippy`

### DIFF
--- a/ark-cli/src/models/storage.rs
+++ b/ark-cli/src/models/storage.rs
@@ -376,10 +376,7 @@ impl Storage {
                                 false
                             }
                         })
-                        .filter_map(|e| match AtomicFile::new(e.path()) {
-                            Ok(file) => Some(file),
-                            Err(_) => None,
-                        });
+                        .filter_map(|e| AtomicFile::new(e.path()).ok());
 
                     writeln!(
                         output,

--- a/drop-core/src/lib.rs
+++ b/drop-core/src/lib.rs
@@ -386,8 +386,6 @@ mod test {
         sync::{mpsc::channel, Arc},
     };
 
-    use tokio;
-
     use crate::{FileTransfer, IrohInstance};
 
     #[tokio::test]
@@ -430,7 +428,7 @@ mod test {
         let ticket = send_instance.send_files(files).await.unwrap();
         let ticket_str = ticket.to_string();
 
-        let (tx, mut rx) = channel::<Vec<FileTransfer>>();
+        let (tx, _rx) = channel::<Vec<FileTransfer>>();
         let handle = Arc::new(crate::FileTransferHandle(tx)); // Assuming FileTransferHandle wraps the sender
 
         let collection = receive_instance

--- a/fs-index/src/tests.rs
+++ b/fs-index/src/tests.rs
@@ -923,7 +923,7 @@ fn test_track_modification_with_collision() {
 /// - Move the file to a subdirectory.
 /// - Call `update_one()` 2 times with the relative path of the moved file.
 /// - Assert that the index contains the expected number of entries with the
-///  correct IDs and paths after the move.
+/// - correct IDs and paths after the move.
 #[test]
 fn test_track_move_to_subdirectory() {
     for_each_type!(Crc32, Blake3 => {


### PR DESCRIPTION
# Clippy Warnings Fix

## Description
This PR fixes all clippy warnings across the workspace when running `cargo clippy --workspace --tests --bins -- -D warnings`.

Fixes [#53](https://github.com/ARK-Builders/ark-core/issues/53)

## Changes

### **drop-core/src/lib.rs:**
- Removed redundant `use tokio;` import in test module
- Fixed unused variable by changing `mut rx` to `_rx`
- Removed unnecessary `mut` from unused variable

### **fs-storage/src/folder_storage.rs:**
- Replaced `assert_eq!(condition, true)` with `assert!(condition)`
- Removed needless borrows from `fs::metadata()` calls
- Changed OR pattern `0 | 1 | 2 | 3 | 4` to range pattern `0..=4`
- Removed needless borrow in `FolderStorage::new()` call
- Replaced `.map_or(true, |closure|)` with `.is_none_or(|closure|)` (2 instances)

### **fs-index/src/tests.rs:**
- Fixed documentation formatting by adding proper indentation to doc comment

### **ark-cli/src/models/storage.rs:**
- Replaced manual `match Ok/Err` pattern with `.ok()` method